### PR TITLE
feat(contract): Store authorizer and actionCounter in the same slot

### DIFF
--- a/contracts/interfaces/IMorphoManagement.sol
+++ b/contracts/interfaces/IMorphoManagement.sol
@@ -88,6 +88,16 @@ interface IMorphoManagement {
     event OnMorphoRepay(uint256 repaidAssets, bytes data);
 
     /**
+        @notice Struct that stores information for a market action
+        @param authorizer The authorizer for the APM
+        @param actionCounter It is incremented when some authorized actions are performed for each position
+     */
+    struct MarketAccess {
+        address authorizer;
+        uint96 actionCounter;
+    }
+
+    /**
         @notice Supply collateral to an apm'position on Morpho
         @dev Called by anyone, but requires valid signature from the authorizer
         @dev The position can be supplied collateral if and only if:
@@ -189,6 +199,8 @@ interface IMorphoManagement {
         bytes32 role,
         address account
     ) external view returns (bool);
+
+    function marketAccess(address apm) external view returns (address authorizer, uint96 actionCounter);
 
     // /**
     //     @notice Checks the validity of the provided `apm`

--- a/contracts/utils/MorphoManagementSigner.sol
+++ b/contracts/utils/MorphoManagementSigner.sol
@@ -20,14 +20,14 @@ contract MorphoManagementSigner is EIP712 {
         0x08ae5b019b96dfc6531fe4156aafc1cf288947578b56a9430efc623bbadc8e33;
 
     /// @notice EIP-712 typehash for the borrow operation
-    /// @dev keccak256("Borrow(address apm,uint256 assets,address recipient,uint256 nonce,uint256 deadline)");
+    /// @dev keccak256("Borrow(address apm,uint256 assets,address recipient,uint96 nonce,uint256 deadline)");
     bytes32 private constant _BORROW_TYPEHASH =
-        0xda4b426f381fd2bc183e218eed1c34a6dd86c29a586381f9a768a14889422ebb;
+        0xee89eb2d832b54ef2d13c4f58add9df5d83af50de3a9de193a9a52727f9f4db8;
 
     /// @notice EIP-712 typehash for the withdraw collateral operation
-    /// @dev keccak256("WithdrawCollateral(address apm,uint256 assets,uint256 nonce,uint256 deadline)");
+    /// @dev keccak256("WithdrawCollateral(address apm,uint256 assets,uint96 nonce,uint256 deadline)");
     bytes32 private constant _WITHDRAW_COLLATERAL_TYPEHASH =
-        0x0ab847d92cbc3ab01c5a721efd1585ef8baedd2dfd9a1292bf556ecf41432ad4;
+        0xd46b7a7b666e1f081fab75b7ce5e811ff844892501a5cd8fbea8a7478da3d2fe;
 
     /// @notice EIP-712 typehash for verifying the APM generation
     /// @dev keccak256("APMGenerated(address apm,uint256 deadline)")
@@ -120,7 +120,7 @@ contract MorphoManagementSigner is EIP712 {
         address apm,
         uint256 assets,
         address recipient,
-        uint256 nonce,
+        uint96 nonce,
         uint256 deadline,
         bytes memory signature
     ) internal view returns (bool isValid) {
@@ -154,7 +154,7 @@ contract MorphoManagementSigner is EIP712 {
         address signer,
         address apm,
         uint256 assets,
-        uint256 nonce,
+        uint96 nonce,
         uint256 deadline,
         bytes memory signature
     ) internal view returns (bool isValid) {

--- a/test/foundry/account_position/Borrow.t.sol
+++ b/test/foundry/account_position/Borrow.t.sol
@@ -52,7 +52,7 @@ contract BorrowTest is BaseMainnetTest, BaseLocalTest {
     function test_BorrowSuccess() public {
         uint256 assets = 50000e6;
         // Borrow 50_000 USDC
-        uint256 authorizerNonce = MORPHO_MANAGEMENT.actionCounters(APM);
+        (,uint96 authorizerNonce) = MORPHO_MANAGEMENT.marketAccess(APM);
 
         vm.prank(AUTHORIZER);
         bytes memory signature = _signBorrow(
@@ -89,9 +89,11 @@ contract BorrowTest is BaseMainnetTest, BaseLocalTest {
             position.borrowShares,
             "BORROWER should borrow all shares"
         );
+        
+        (, uint96 counter) = MORPHO_MANAGEMENT.marketAccess(APM);
 
         assertEq(
-            MORPHO_MANAGEMENT.actionCounters(APM),
+            counter,
             1,
             "Nonces should be 1"
         );
@@ -105,7 +107,7 @@ contract BorrowTest is BaseMainnetTest, BaseLocalTest {
     function test_BorrowFailureOverCollateral() public {
         uint256 assets = 110_000e6;
         // Borrow 50_000 USDC
-        uint256 authorizerNonce = MORPHO_MANAGEMENT.actionCounters(APM);
+        (, uint96 authorizerNonce) = MORPHO_MANAGEMENT.marketAccess(APM);
 
         vm.prank(AUTHORIZER);
         bytes memory signature = _signBorrow(
@@ -168,7 +170,7 @@ contract BorrowTest is BaseMainnetTest, BaseLocalTest {
     function test_BorrowFailureNotAuthorizer() public {
         uint256 assets = 50000e6;
         // Borrow 50_000 USDC
-        uint256 authorizerNonce = MORPHO_MANAGEMENT.actionCounters(APM);
+        (,uint96 authorizerNonce) = MORPHO_MANAGEMENT.marketAccess(APM);
 
         vm.prank(AUTHORIZER);
         uint256 AUTHORIZER2_PK = uint256(keccak256("AUTHORIZER_2"));

--- a/test/foundry/account_position/CreateAPM.t.sol
+++ b/test/foundry/account_position/CreateAPM.t.sol
@@ -55,7 +55,8 @@ contract CreateAPMTest is BaseMainnetTest, BaseLocalTest {
         );
 
         assertEq(MORPHO_MANAGEMENT.apmValidators(apm), VALIDATOR);
-        assertEq(MORPHO_MANAGEMENT.apmAuthorizers(apm), authorizer);
+        (address _authorizer, ) = MORPHO_MANAGEMENT.marketAccess(apm);
+        assertEq(_authorizer, authorizer);
         assertEq(MORPHO.isAuthorized(apm, address(MORPHO_MANAGEMENT)), true);
     }
 

--- a/test/foundry/account_position/SupplyCollateral.t.sol
+++ b/test/foundry/account_position/SupplyCollateral.t.sol
@@ -56,7 +56,7 @@ contract SupplyCollateralTest is BaseMainnetTest, BaseLocalTest {
             address(APM)
         );
         assertEq(position.collateral, amount, "Collateral should be 1 BTC");
-        address authorizer = MORPHO_MANAGEMENT.apmAuthorizers(APM);
+        (address authorizer, ) = MORPHO_MANAGEMENT.marketAccess(APM);
         uint256 loanIndex = MORPHO_MANAGEMENT.loanCounters(APM);
         assertEq(
             MORPHO_MANAGEMENT.apmMarkets(APM),

--- a/test/foundry/account_position/Withdraw.t.sol
+++ b/test/foundry/account_position/Withdraw.t.sol
@@ -56,7 +56,7 @@ contract WithdrawTest is BaseMainnetTest, BaseLocalTest {
         uint256 balanceBefore = BTC.balanceOf(address(BTC));
         vm.prank(AUTHORIZER);
         uint256 deadline = block.timestamp + 1000;
-        uint256 authorizerNonce = MORPHO_MANAGEMENT.actionCounters(APM);
+        (, uint96 authorizerNonce) = MORPHO_MANAGEMENT.marketAccess(APM);
         bytes memory signature = _signWithdraw(
             AUTHORIZER_PRIVATE_KEY,
             APM,
@@ -77,7 +77,7 @@ contract WithdrawTest is BaseMainnetTest, BaseLocalTest {
             balanceBefore + 1e8,
             "oBTC balance should increase by 1e8"
         );
-        uint256 authorizerNonce2 = MORPHO_MANAGEMENT.actionCounters(APM);
+        (, uint96 authorizerNonce2) = MORPHO_MANAGEMENT.marketAccess(APM);
         assertEq(
             authorizerNonce2,
             authorizerNonce + 1,
@@ -91,7 +91,7 @@ contract WithdrawTest is BaseMainnetTest, BaseLocalTest {
         uint256 assets = 1e8;
         vm.prank(BORROWER);
         uint256 deadline = block.timestamp + 1000;
-        uint256 authorizerNonce = MORPHO_MANAGEMENT.actionCounters(APM);
+        (, uint96 authorizerNonce) = MORPHO_MANAGEMENT.marketAccess(APM);
         bytes memory signature = _signWithdraw(
             BORROWER_PRIVATE_KEY,
             APM,
@@ -116,7 +116,7 @@ contract WithdrawTest is BaseMainnetTest, BaseLocalTest {
         uint256 assets = 1e8 - 1;
         vm.prank(BORROWER);
         uint256 deadline = block.timestamp + 1000;
-        uint256 authorizerNonce = MORPHO_MANAGEMENT.actionCounters(APM);
+        (, uint96 authorizerNonce) = MORPHO_MANAGEMENT.marketAccess(APM);
         bytes memory signature = _signWithdraw(
             AUTHORIZER_PRIVATE_KEY,
             APM,
@@ -141,7 +141,7 @@ contract WithdrawTest is BaseMainnetTest, BaseLocalTest {
         uint256 assets = 1e8 + 1;
         vm.prank(BORROWER);
         uint256 deadline = block.timestamp + 1000;
-        uint256 authorizerNonce = MORPHO_MANAGEMENT.actionCounters(APM);
+        (, uint96 authorizerNonce) = MORPHO_MANAGEMENT.marketAccess(APM);
         bytes memory signature = _signWithdraw(
             AUTHORIZER_PRIVATE_KEY,
             APM,

--- a/test/foundry/common/Utils.t.sol
+++ b/test/foundry/common/Utils.t.sol
@@ -20,12 +20,12 @@ contract Utils is Test {
 
     bytes32 private constant _BORROW_TYPEHASH =
         keccak256(
-            "Borrow(address apm,uint256 assets,address recipient,uint256 nonce,uint256 deadline)"
+            "Borrow(address apm,uint256 assets,address recipient,uint96 nonce,uint256 deadline)"
         );
 
     bytes32 private constant _WITHDRAW_COLLATERAL_TYPEHASH =
         keccak256(
-            "WithdrawCollateral(address apm,uint256 assets,uint256 nonce,uint256 deadline)"
+            "WithdrawCollateral(address apm,uint256 assets,uint96 nonce,uint256 deadline)"
         );
 
     bytes32 private constant _CLAIM_REFUND_TYPEHASH =
@@ -196,7 +196,7 @@ contract Utils is Test {
         address apm,
         uint256 assets,
         address receiver,
-        uint256 nonce,
+        uint96 nonce,
         uint256 deadline,
         address morphoManagement
     ) private view returns (bytes32) {
@@ -230,7 +230,7 @@ contract Utils is Test {
         address apm,
         uint256 assets,
         address receiver,
-        uint256 nonce,
+        uint96 nonce,
         uint256 deadline,
         address morphoManagement
     ) internal view returns (bytes memory) {
@@ -249,7 +249,7 @@ contract Utils is Test {
     function _getWithdrawCollateralTypedDataHash(
         address apm,
         uint256 assets,
-        uint256 nonce,
+        uint96 nonce,
         uint256 deadline,
         address morphoManagement
     ) private view returns (bytes32) {
@@ -286,7 +286,7 @@ contract Utils is Test {
         uint256 privateKey,
         address apm,
         uint256 assets,
-        uint256 nonce,
+        uint96 nonce,
         uint256 deadline,
         address morphoManagement
     ) internal view returns (bytes memory) {


### PR DESCRIPTION
- Store `authorizer` and `actionCounter` in the same slot